### PR TITLE
Add configurable server port via PORT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ already included within the image.
 
 We provide a `docker-compose.yml` configuration file. Clone this repository and execute
 `docker compose up -d` to start
-the container.
+the container. The server listens on **port 8080** inside the container by default (mapped to 20080 on the host). To use a different port, set the `PORT` environment variable (e.g. `PORT=3000`) and adjust the `ports` mapping in `docker-compose.yml` (e.g. `20080:3000`).
 
 ### From github as pip package
 > **Warning**
@@ -41,7 +41,7 @@ the container.
 * (Only in macOS) Install [XQuartz](https://www.xquartz.org/) package.
 * If you plan to use proxy with authorization : install [gost](https://github.com/ginuerzh/gost).
 * Run `pip install git+https://github.com/yoori/flare-bypasser.git`.
-* Run `flare_bypass_server` command to start FlareBypasser.
+* Run `flare_bypass_server` command to start FlareBypasser. The server binds to `127.0.0.1:8000` by default. Set the `PORT` environment variable to use another port (e.g. `PORT=8080`).
 
 ### From source code
 
@@ -57,9 +57,11 @@ the container.
 * If you plan to use proxy with authorization : install [gost](https://github.com/ginuerzh/gost).
 * Clone this repository.
 * Run `pip install .` (from project root).
-* Run `flare_bypass_server` command to start FlareBypasser.
+* Run `flare_bypass_server` command to start FlareBypasser. The server binds to `127.0.0.1:8000` by default. Set the `PORT` environment variable to use another port.
 
 ## Usage
+
+**Port:** When run via Docker the server listens on port **8080** (host mapping is 20080 by default). When run via pip/source the default is **8000**. You can set the `PORT` environment variable to change the listen port; with Docker, also set the port mapping (e.g. `ports: - "20080:3000"` if `PORT=3000`). The examples below use `localhost:8080` (Docker); use your port if different.
 
 Example Bash request:
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       dockerfile: Dockerfile
     environment:
       UNUSED: "false"
+      # PORT: "8080"   # Server listen port (default 8080). Set to change; update ports mapping below if needed.
       # FORKS: "5:3" #< Uncomment if you work with sites with ustable challenge loading (start additional 3 forks after 5 seconds).
       DEBUG: "false"
       VERBOSE: "false"
@@ -18,7 +19,8 @@ services:
     container_name: flare-bypasser
     image: flare-bypasser:latest
     ports:
-      - 20080:8080
+      # Host:container. Container port uses PORT env (default 8080). Example: PORT=3000 -> use "20080:3000"
+      - "${HOST_PORT:-20080}:${PORT:-8080}"
     #volumes:
       #- ./var:/opt/flare_bypasser/var/
       #< Uncomment if you persistent logs between runs

--- a/examples/async_client/README.md
+++ b/examples/async_client/README.md
@@ -5,4 +5,4 @@ without solving challenge for each page.
 It solve challenge when detect it and reuse cookies for bypass challenges after,
 as result usualy you will get solving delay only once.
 
-For use it you need to up docker and use link to it on AsyncClient construction.
+For use it you need to up docker and use link to it on AsyncClient construction. When using Docker with default settings, the solver is at `http://localhost:20080` (host port). If you changed `PORT` in the container, set the host port mapping accordingly and use that URL (e.g. `PORT=3000` with mapping `20080:3000` → `http://localhost:20080`).

--- a/rootfs/opt/flare_bypasser/bin/FlareBypasserRun.sh
+++ b/rootfs/opt/flare_bypasser/bin/FlareBypasserRun.sh
@@ -168,5 +168,6 @@ echo "Run server $(pip show flare-bypasser | grep Version | awk '{print $2}'
 ), chrome: $(/usr/bin/chrome --version
 ), extensions: $EXTENSION_MODULES, add params: $ADD_PARAMS"
 
-flare_bypass_server -b 0.0.0.0:8080 $EXTENSION_MODULES_PARAM $ADD_PARAMS 2>&1 | \
+SERVER_PORT=${PORT:-8080}
+flare_bypass_server -b 0.0.0.0:$SERVER_PORT $EXTENSION_MODULES_PARAM $ADD_PARAMS 2>&1 | \
   tee "$WORKSPACE_ROOT/log/flare_bypass_server.log"

--- a/src/flare_bypasser/flare_bypass_server.py
+++ b/src/flare_bypasser/flare_bypass_server.py
@@ -626,10 +626,16 @@ def parse_solve_forks(solve_forks: str):
 
 
 def init_args_parser():
+  # Default bind: use PORT env for port if set, else 127.0.0.1:8000 (or 0.0.0.0:PORT in Docker via -b)
+  port_from_env = os.environ.get('PORT')
+  default_bind = ('127.0.0.1:' + port_from_env) if port_from_env else '127.0.0.1:8000'
+
   parser = argparse.ArgumentParser(
     description='Start flare_bypass server.',
     epilog='Other arguments will be passed to gunicorn or uvicorn(win32) as is.')
-  parser.add_argument("-b", "--bind", type=str, default='127.0.0.1:8000')
+  parser.add_argument(
+    "-b", "--bind", type=str, default=default_bind,
+    help="Host:port to bind (e.g. 127.0.0.1:8000 or 0.0.0.0:8080). Default port is from PORT env if set, else 8000.")
   # < parse for pass to gunicorn as is and as "--host X --port X" to uvicorn
   parser.add_argument("--extensions", nargs='*', type=str)
   parser.add_argument(


### PR DESCRIPTION
## Summary
Makes the FlareBypasser server listen port configurable via the `PORT` environment variable instead of hardcoding 8080 (Docker) and 8000 (pip/source).

## Changes
- **Server (`flare_bypass_server.py`):** Default `--bind` uses `PORT` when set (e.g. `127.0.0.1:$PORT`), otherwise `127.0.0.1:8000`. Help text for `-b` updated.
- **Docker entrypoint (`FlareBypasserRun.sh`):** Bind address uses `0.0.0.0:${PORT:-8080}` so the container listens on `PORT` or 8080.
- **Docker Compose:** Port mapping set to `${HOST_PORT:-20080}:${PORT:-8080}` and optional `PORT` (and `HOST_PORT`) documented in comments.
- **Docs:** README and async_client example updated with port behaviour, defaults, and how to change the port in Docker and when running locally.

## Usage
- **Docker:** Set `PORT=3000` (and e.g. `ports: - "20080:3000"`) to run the server on port 3000.
- **Local:** `PORT=8080 flare_bypass_server` or `flare_bypass_server -b 0.0.0.0:8080`.